### PR TITLE
Simplify dashboard configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ below along with their default settings:
 - Enable playing games inside Neovim!
   - `conf.enable_games = true`
 - Enable the Alpha dashboard
-  - `conf.enable_alpha = true`
+  - `conf.dashboard = "alpha"`
 - Enable the Neovim bookmarks plugin (<https://github.com/ldelossa/nvim-ide>)
   - `conf.enable_bookmarks = false`
 - Enable the Neovim IDE plugin (<https://github.com/ldelossa/nvim-ide>)
@@ -868,22 +868,8 @@ conf.enable_winbar = true
 conf.enable_terminal = true
 -- Enable playing games inside Neovim!
 conf.enable_games = true
---
--- Enable preferred dashboard, disable all for no dashboard
---
--- Enable the Alpha dashboard
-conf.enable_alpha = true
--- Enable the dashboard-nvim dashboard
-conf.enable_dashboard = false
--- Enable the Mini Starter dashboard
-conf.enable_mini_starter = false
---
--- TODO: fix startup dashboard configuration
--- Enable the Startup dashboard
--- conf.enable_startup = false
--- Startup dashboard theme ("dashboard", "lazyman", or "startify")
--- conf.startup_theme = "lazyman"
---
+-- Enable a dashboard, can be one of "alpha", "dash", "mini", or "none"
+conf.dashboard = "alpha"
 -- Number of recent files, dashboard header and quick links settings
 -- only apply to the Alpha dashboard
 -- Number of recent files shown in dashboard
@@ -930,8 +916,8 @@ conf.lsp_servers = {
 conf.formatters_linters = {
   "actionlint", "goimports", "gofumpt", "golangci-lint",
   "google-java-format", "latexindent", "markdownlint",
-  "prettier", "sql-formatter", "shellcheck",
-  "shfmt", "stylua", "tflint", "yamllint",
+  "prettier", "sql-formatter", "shellcheck", "shfmt",
+  "stylua", "tflint", "yamllint",
 }
 -- enable greping in hidden files
 conf.telescope_grep_hidden = true

--- a/doc/Lazyman.txt
+++ b/doc/Lazyman.txt
@@ -425,7 +425,7 @@ below along with their default settings:
 - Enable playing games inside Neovim!
     - `conf.enable_games = true`
 - Enable the Alpha dashboard
-    - `conf.enable_alpha = true`
+    - `conf.dashboard = "alpha"`
 - Enable the Neovim bookmarks plugin (<https://github.com/ldelossa/nvim-ide>)
     - `conf.enable_bookmarks = false`
 - Enable the Neovim IDE plugin (<https://github.com/ldelossa/nvim-ide>)

--- a/lazyman.sh
+++ b/lazyman.sh
@@ -1253,16 +1253,7 @@ show_conf_menu() {
     else
       use_games="✗"
     fi
-    enable_alpha=$(get_conf_value enable_alpha)
-    enable_dashboard=$(get_conf_value enable_dashboard)
-    enable_mini_starter=$(get_conf_value enable_mini_starter)
-    if [ "${enable_alpha}" == "true" ]; then
-      use_dash="alpha"
-    elif [ "${enable_mini_starter}" == "true" ]; then
-        use_dash="mini"
-    elif [ "${enable_dashboard}" == "true" ]; then
-        use_dash="dash"
-    fi
+    use_dash=$(get_conf_value dashboard)
     enable_bookmarks=$(get_conf_value enable_bookmarks)
     if [ "${enable_bookmarks}" == "true" ]; then
       use_bookmarks=""
@@ -1340,7 +1331,7 @@ show_conf_menu() {
       options+=("Style [${use_theme_style}]")
     fi
     options+=("Dashboard [${use_dash}]")
-    if [ "${enable_alpha}" == "true" ]; then
+    if [ "${use_dash}" == "alpha" ]; then
       options+=("Alpha Header  [${use_dashboard_header}]")
       options+=("Recent Files  [${use_dashboard_recent_files}]")
       options+=("Quick Links   [${use_dashboard_quick_links}]")
@@ -1540,25 +1531,11 @@ show_conf_menu() {
           break
           ;;
         "Dashboard"*,* | *,"Dashboard"*)
-          choices=("alpha" "dashboard" "mini")
+          choices=("alpha" "dash" "mini" "none")
           choice=$(printf "%s\n" "${choices[@]}" | fzf --prompt=" Neovim Dashboard  " --layout=reverse --border --exit-0)
-          if [ "${choice}" == "alpha" ]; then
-            set_conf_value "enable_dashboard" "false"
-            set_conf_value "enable_mini_starter" "false"
-            [ "${enable_alpha}" == "true" ] || {
-              set_conf_value "enable_alpha" "true"
-            }
-          elif [ "${choice}" == "dashboard" ]; then
-            set_conf_value "enable_alpha" "false"
-            set_conf_value "enable_mini_starter" "false"
-            [ "${enable_dashboard}" == "true" ] || {
-              set_conf_value "enable_dashboard" "true"
-            }
-          elif [ "${choice}" == "mini" ]; then
-            set_conf_value "enable_alpha" "false"
-            set_conf_value "enable_dashboard" "false"
-            [ "${enable_mini_starter}" == "true" ] || {
-              set_conf_value "enable_mini_starter" "true"
+          if [[ " ${choices[*]} " =~ " ${choice} " ]]; then
+            [ "${choice}" == "${use_dash}" ] || {
+              set_conf_value "dashboard" "${choice}"
             }
           fi
           break

--- a/lazyman.sh
+++ b/lazyman.sh
@@ -501,7 +501,19 @@ update_config() {
   }
   [ "${ndir}" == "${lazymandir}" ] && {
     [ -f /tmp/lazyconf$$ ] && {
-      cp /tmp/lazyconf$$ "${HOME}/${GITDIR}/lua/configuration.lua"
+      if grep 'conf.enable_alpha' /tmp/lazyconf$$ > /dev/null
+      then
+        cp /tmp/lazyconf$$ "${HOME}/${GITDIR}/lua/configuration-prev.lua"
+        printf "\n\nThe format of the Lazyman configuration file has changed."
+        printf "\nSaving your previous configuration file as:"
+        printf "\n\t${HOME}/${GITDIR}/lua/configuration-prev.lua"
+        printf "\nRe-apply any customizations to the new config at:"
+        printf "\n\t${HOME}/${GITDIR}/lua/configuration.lua"
+        printf "\nPress Enter to continue\n"
+        read -r yn
+      else
+        cp /tmp/lazyconf$$ "${HOME}/${GITDIR}/lua/configuration.lua"
+      fi
       rm -f /tmp/lazyconf$$
     }
     [ -d "${HOME}"/.local/bin ] || mkdir -p "${HOME}"/.local/bin

--- a/lazyman.sh
+++ b/lazyman.sh
@@ -1364,6 +1364,8 @@ show_conf_menu() {
     options+=("Status Line   [${use_statusline}]")
     options+=("Tab Line      [${use_tabline}]")
     options+=("Winbar        [${use_winbar}]")
+    options+=("Disable All")
+    options+=("Enable All")
     [ -f ${CONFBACK} ] && {
       diff ${CONFBACK} ${NVIMCONF} >/dev/null || options+=("Reset to Defaults")
     }
@@ -1646,6 +1648,68 @@ show_conf_menu() {
           else
             set_conf_value "convert_semantic_highlighting" "true"
           fi
+          break
+          ;;
+        "Disable All"*,* | *,"Disable All"*)
+          set_conf_value "dashboard" "none"
+          set_conf_value "number" "false"
+          set_conf_value "relative_number" "false"
+          set_conf_value "enable_statusline" "false"
+          set_conf_value "enable_tabline" "false"
+          set_conf_value "enable_winbar" "false"
+          set_conf_value "enable_transparent" "false"
+          set_conf_value "enable_neotree" "false"
+          set_conf_value "enable_noice" "false"
+          set_conf_value "enable_chatgpt" "false"
+          set_conf_value "enable_rainbow2" "false"
+          set_conf_value "enable_fancy" "false"
+          set_conf_value "enable_wilder" "false"
+          set_conf_value "enable_terminal" "false"
+          set_conf_value "enable_games" "false"
+          set_conf_value "enable_bookmarks" "false"
+          set_conf_value "enable_ide" "false"
+          set_conf_value "enable_navigator" "false"
+          set_conf_value "enable_project" "false"
+          set_conf_value "enable_picker" "false"
+          set_conf_value "enable_smooth_scrolling" "false"
+          set_conf_value "enable_dashboard_header" "false"
+          set_conf_value "enable_dashboard_quick_links" "false"
+          set_conf_value "enable_color_indentline" "false"
+          set_conf_value "show_diagnostics" "none"
+          set_conf_value "enable_semantic_highlighting" "false"
+          set_conf_value "convert_semantic_highlighting" "false"
+          set_conf_value "list" "false"
+          break
+          ;;
+        "Enable All"*,* | *,"Enable All"*)
+          set_conf_value "dashboard" "dash"
+          set_conf_value "number" "true"
+          set_conf_value "relative_number" "true"
+          set_conf_value "enable_statusline" "true"
+          set_conf_value "enable_tabline" "true"
+          set_conf_value "enable_winbar" "true"
+          set_conf_value "enable_transparent" "true"
+          set_conf_value "enable_neotree" "true"
+          set_conf_value "enable_noice" "true"
+          set_conf_value "enable_chatgpt" "true"
+          set_conf_value "enable_rainbow2" "true"
+          set_conf_value "enable_fancy" "true"
+          set_conf_value "enable_wilder" "true"
+          set_conf_value "enable_terminal" "true"
+          set_conf_value "enable_games" "true"
+          set_conf_value "enable_bookmarks" "true"
+          set_conf_value "enable_ide" "true"
+          set_conf_value "enable_navigator" "true"
+          set_conf_value "enable_project" "true"
+          set_conf_value "enable_picker" "true"
+          set_conf_value "enable_smooth_scrolling" "true"
+          set_conf_value "enable_dashboard_header" "true"
+          set_conf_value "enable_dashboard_quick_links" "true"
+          set_conf_value "enable_color_indentline" "true"
+          set_conf_value "show_diagnostics" "popup"
+          set_conf_value "enable_semantic_highlighting" "true"
+          set_conf_value "convert_semantic_highlighting" "true"
+          set_conf_value "list" "true"
           break
           ;;
         "Reset"*,* | *,"Reset"*)

--- a/lua/autocmds.lua
+++ b/lua/autocmds.lua
@@ -136,7 +136,7 @@ vim.api.nvim_create_autocmd("UIEnter", {
   end,
 })
 
-if settings.enable_alpha then
+if settings.dashboard == "alpha" then
   local alpha_group = vim.api.nvim_create_augroup("alpha_autocmd", { clear = true })
 
   vim.api.nvim_create_autocmd("User", {
@@ -188,29 +188,6 @@ if settings.enable_alpha then
         vim.api.nvim_command("Alpha")
         vim.api.nvim_command(event.buf .. "bwipeout")
       end
-    end,
-  })
-elseif settings.enable_startup then
-  local st_group = vim.api.nvim_create_augroup("Startup_au", { clear = true })
-  vim.api.nvim_create_autocmd("Filetype", {
-    pattern = "startup",
-    group = st_group,
-    callback = function()
-      require("lualine").hide({
-        place = { "statusline", "tabline", "winbar" },
-        unhide = false,
-      })
-    end,
-  })
-
-  vim.api.nvim_create_autocmd("BufUnload", {
-    desc = "enable status and tabline after dashboard",
-    group = st_group,
-    callback = function()
-      require("lualine").hide({
-        place = { "statusline", "tabline", "winbar" },
-        unhide = true,
-      })
     end,
   })
 end

--- a/lua/configuration.lua
+++ b/lua/configuration.lua
@@ -73,22 +73,8 @@ conf.enable_winbar = true
 conf.enable_terminal = true
 -- Enable playing games inside Neovim!
 conf.enable_games = true
---
--- Enable preferred dashboard, disable all for no dashboard
---
--- Enable the Alpha dashboard
-conf.enable_alpha = true
--- Enable the dashboard-nvim dashboard
-conf.enable_dashboard = false
--- Enable the Mini Starter dashboard
-conf.enable_mini_starter = false
---
--- TODO: fix startup dashboard configuration
--- Enable the Startup dashboard
--- conf.enable_startup = false
--- Startup dashboard theme ("dashboard", "lazyman", or "startify")
--- conf.startup_theme = "lazyman"
---
+-- Enable a dashboard, can be one of "alpha", "dash", "mini", or "none"
+conf.dashboard = "alpha"
 -- Number of recent files, dashboard header and quick links settings
 -- only apply to the Alpha dashboard
 -- Number of recent files shown in dashboard

--- a/lua/plugins/dashboards.lua
+++ b/lua/plugins/dashboards.lua
@@ -40,7 +40,7 @@ elseif settings.dashboard == "mini" then
     enabled = true,
     event = "VimEnter",
     opts = function()
-      local pad = string.rep(" ", 10)
+      local pad = string.rep(" ", 18)
       local new_section = function(name, action, section)
         return { name = name, action = action, section = pad .. section }
       end
@@ -55,7 +55,7 @@ elseif settings.dashboard == "mini" then
           local day_part =
             ({ 'evening', 'morning', 'afternoon', 'evening' })[part_id]
           local username = vim.loop.os_get_passwd()['username'] or 'USERNAME'
-          return ('  Greetings! Good %s, %s'):format(day_part, username)
+          return ('        Greetings! Good %s, %s'):format(day_part, username)
         end,
         items = {
           new_section("Find file",          "Telescope find_files", "Telescope"),
@@ -95,9 +95,18 @@ elseif settings.dashboard == "mini" then
       vim.api.nvim_create_autocmd("User", {
         pattern = "MiniStarterOpened",
         callback = function()
+          local datetime = os.date("  %Y-%b-%d   %H:%M:%S", os.time())
+          local version = vim.version()
+          local version_info = ""
+          if version ~= nil then
+            version_info = "v" .. version.major .. "." ..
+                                  version.minor .. "." .. version.patch
+          end
           local stats = require("lazy").stats()
-          starter.config.footer =
-            "⚡ Lazyman Neovim loaded " .. stats.count .. " plugins"
+          local vinfo = "Neovim " .. version_info
+          local lazystats = "  loaded " .. stats.count .. " plugins "
+          starter.config.footer = datetime .. "  " .. vinfo .. lazystats
+          -- "⚡ Lazyman Neovim loaded " .. stats.count .. " plugins"
           pcall(starter.refresh)
         end,
       })

--- a/lua/plugins/dashboards.lua
+++ b/lua/plugins/dashboards.lua
@@ -2,7 +2,6 @@ local settings = require("configuration")
 local dashboard_type = {}
 local alpha_disabled = { "goolord/alpha-nvim", enabled = false }
 local mini_disabled = { "echasnovski/mini.starter", enabled = false }
-local startup_disabled = { "startup-nvim/startup.nvim", enabled = false }
 local dashboard_disabled = { "glepnir/dashboard-nvim", enabled = false }
 
 local session_restore = 'lua require("persistence").load()'
@@ -10,7 +9,7 @@ if settings.session_manager == "possession" then
   session_restore = 'lua require("possession").list()'
 end
 
-if settings.enable_alpha then
+if settings.dashboard == "alpha" then
   alpha_disabled = {}
   dashboard_type = {
     "goolord/alpha-nvim",
@@ -21,7 +20,7 @@ if settings.enable_alpha then
       require("config.alpha.alpha")
     end
   }
-elseif settings.enable_dashboard then
+elseif settings.dashboard == "dash" then
   dashboard_disabled = {}
   dashboard_type = {
     "glepnir/dashboard-nvim",
@@ -33,24 +32,7 @@ elseif settings.enable_dashboard then
       require("config.dashboard")
     end,
   }
-elseif settings.enable_startup then
-  startup_disabled = {}
-  dashboard_type = {
-    "startup-nvim/startup.nvim",
-    enabled = true,
-    dependencies = {
-      "nvim-telescope/telescope.nvim",
-      "nvim-lua/plenary.nvim",
-    },
-    event = "VimEnter",
-    keys = { { "<leader>S", "<cmd>Startup display<CR>", "Startup Dashboard" } },
-    config = function()
-      vim.g.startup_disable_on_startup = false
-      local startup_config = "config.startup." .. settings.startup_theme
-      require("startup").setup(require(startup_config))
-    end
-  }
-elseif settings.enable_mini_starter then
+elseif settings.dashboard == "mini" then
   mini_disabled = {}
   dashboard_type = {
     "echasnovski/mini.starter",
@@ -114,7 +96,8 @@ elseif settings.enable_mini_starter then
         pattern = "MiniStarterOpened",
         callback = function()
           local stats = require("lazy").stats()
-          starter.config.footer = "⚡ Lazyman Neovim loaded " .. stats.count .. " plugins"
+          starter.config.footer =
+            "⚡ Lazyman Neovim loaded " .. stats.count .. " plugins"
           pcall(starter.refresh)
         end,
       })
@@ -149,5 +132,4 @@ return {
   alpha_disabled,
   dashboard_disabled,
   mini_disabled,
-  startup_disabled
 }

--- a/lua/themes/catppuccin.lua
+++ b/lua/themes/catppuccin.lua
@@ -236,7 +236,7 @@ catppuccin.setup({
 })
 if settings.theme == "catppuccin" then
   set_colorscheme(style)
-  if settings.enable_alpha then
+  if settings.dashboard == "alpha" then
     vim.api.nvim_set_hl(0, "AlphaHeader", { link = "DashboardHeader" })
     vim.api.nvim_set_hl(0, "AlphaHeaderLabel", { link = "DashboardHeader" })
     vim.api.nvim_set_hl(0, "AlphaButtons", { link = "DashboardCenter" })

--- a/lua/themes/dracula.lua
+++ b/lua/themes/dracula.lua
@@ -168,7 +168,7 @@ end
 
 if settings.theme == "dracula" then
   vim.cmd([[colorscheme dracula]])
-  if settings.enable_alpha then
+  if settings.dashboard == "alpha" then
     vim.api.nvim_set_hl(0, "AlphaHeader", { link = "Type" })
     vim.api.nvim_set_hl(0, "AlphaHeaderLabel", { link = "Type" })
     vim.api.nvim_set_hl(0, "AlphaButtons", { link = "Keyword" })

--- a/lua/themes/everforest.lua
+++ b/lua/themes/everforest.lua
@@ -26,7 +26,7 @@ require("everforest").setup({
 -- setup must be called before loading
 if settings.theme == "everforest" then
   vim.cmd([[colorscheme everforest]])
-  if settings.enable_alpha then
+  if settings.dashboard == "alpha" then
     vim.api.nvim_set_hl(0, "AlphaHeader", { link = "DashboardHeader" })
     vim.api.nvim_set_hl(0, "AlphaHeaderLabel", { link = "DashboardHeader" })
     vim.api.nvim_set_hl(0, "AlphaButtons", { link = "DashboardCenter" })

--- a/lua/themes/kanagawa.lua
+++ b/lua/themes/kanagawa.lua
@@ -56,7 +56,7 @@ if settings.theme == "kanagawa" then
     vim.api.nvim_set_hl(0, "NeoTreeNormalNC", { link = "NvimTreeNormalNC" })
     vim.api.nvim_set_hl(0, "NeoTreeSymbolicLinkTarget", { link = "NvimTreeSymlink" })
   end
-  if settings.enable_alpha then
+  if settings.dashboard == "alpha" then
     vim.api.nvim_set_hl(0, "AlphaHeader", { link = "NvimTreeGitStaged" })
     vim.api.nvim_set_hl(0, "AlphaHeaderLabel", { link = "NvimTreeGitStaged" })
     vim.api.nvim_set_hl(0, "AlphaButtons", { link = "NvimTreeImageFile" })

--- a/lua/themes/monokai-pro.lua
+++ b/lua/themes/monokai-pro.lua
@@ -77,7 +77,7 @@ require("monokai-pro").setup({
 
 if settings.theme == "monokai-pro" then
   vim.cmd([[colorscheme monokai-pro]])
-  if settings.enable_alpha then
+  if settings.dashboard == "alpha" then
     vim.api.nvim_set_hl(0, "AlphaShortcut", { link = "DashboardShortcut" })
   end
   local mopts = require("monokai-pro.config").options

--- a/lua/themes/nightfox.lua
+++ b/lua/themes/nightfox.lua
@@ -48,7 +48,7 @@ require("nightfox").setup({
 if settings.theme == "nightfox" then
   local style = settings.theme_style
   set_colorscheme(style)
-  if settings.enable_alpha then
+  if settings.dashboard == "alpha" then
     vim.api.nvim_set_hl(0, "AlphaHeader", { link = "DashboardHeader" })
     vim.api.nvim_set_hl(0, "AlphaHeaderLabel", { link = "DashboardHeader" })
     vim.api.nvim_set_hl(0, "AlphaButtons", { link = "DashboardCenter" })

--- a/lua/themes/onedarkpro.lua
+++ b/lua/themes/onedarkpro.lua
@@ -96,7 +96,7 @@ if theme == "onedarkpro" then
   vim.opt.background = 'dark'
   local style = settings.theme_style
   set_colorscheme(style)
-  if settings.enable_alpha then
+  if settings.dashboard == "alpha" then
     vim.api.nvim_set_hl(0, "AlphaHeader", { link = "StartifyHeader" })
     vim.api.nvim_set_hl(0, "AlphaHeaderLabel", { link = "StartifyHeader" })
     vim.api.nvim_set_hl(0, "AlphaButtons", { link = "StartifySection" })

--- a/lua/themes/tundra.lua
+++ b/lua/themes/tundra.lua
@@ -70,7 +70,7 @@ if settings.theme == "tundra" then
     vim.api.nvim_set_hl(0, "NeoTreeNormalNC", { link = "NvimTreeNormalNC" })
     vim.api.nvim_set_hl(0, "NeoTreeSymbolicLinkTarget", { link = "NvimTreeSymlink" })
   end
-  if settings.enable_alpha then
+  if settings.dashboard == "alpha" then
     vim.api.nvim_set_hl(0, "AlphaHeader", { link = "DiagnosticError" })
     vim.api.nvim_set_hl(0, "AlphaHeaderLabel", { link = "DiagnosticError" })
     vim.api.nvim_set_hl(0, "AlphaButtons", { link = "DiagnosticWarn" })

--- a/man/man1/lazyman.1
+++ b/man/man1/lazyman.1
@@ -608,7 +608,7 @@ Enable playing games inside Neovim!
 Enable the Alpha dashboard
 .RS 2
 .IP \[bu] 2
-\f[V]conf.enable_alpha = true\f[R]
+\f[V]conf.dashboard = \[dq]alpha\[dq]\f[R]
 .RE
 .IP \[bu] 2
 Enable the Neovim bookmarks plugin

--- a/markdown/lazyman.1.md
+++ b/markdown/lazyman.1.md
@@ -389,7 +389,7 @@ below along with their default settings:
 - Enable playing games inside Neovim!
   - `conf.enable_games = true`
 - Enable the Alpha dashboard
-  - `conf.enable_alpha = true`
+  - `conf.dashboard = "alpha"`
 - Enable the Neovim bookmarks plugin (<https://github.com/ldelossa/nvim-ide>)
   - `conf.enable_bookmarks = false`
 - Enable the Neovim IDE plugin (<https://github.com/ldelossa/nvim-ide>)


### PR DESCRIPTION
Use a single entry in `configuration.lua` for dashboard selection. The entry `conf.dashboard` can be one of `alpha`, `dash`, `mini`, or `none`.

Add `Disable All` and `Enable All` config menu entries.